### PR TITLE
Add CKEditor for post content

### DIFF
--- a/resources/views/admin/posts/create.blade.php
+++ b/resources/views/admin/posts/create.blade.php
@@ -64,4 +64,17 @@
         </div>
     </form>
 </div>
-@endsection 
+@endsection
+
+@push('scripts')
+<script src="https://cdn.ckeditor.com/ckeditor5/39.0.0/classic/ckeditor.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        ClassicEditor.create(document.querySelector('textarea[name="content"]'))
+            .then(editor => {
+                editor.ui.view.editable.element.style.minHeight = '400px';
+            })
+            .catch(error => console.error(error));
+    });
+</script>
+@endpush

--- a/resources/views/admin/posts/edit.blade.php
+++ b/resources/views/admin/posts/edit.blade.php
@@ -71,4 +71,17 @@
         </div>
     </form>
 </div>
-@endsection 
+@endsection
+
+@push('scripts')
+<script src="https://cdn.ckeditor.com/ckeditor5/39.0.0/classic/ckeditor.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        ClassicEditor.create(document.querySelector('textarea[name="content"]'))
+            .then(editor => {
+                editor.ui.view.editable.element.style.minHeight = '400px';
+            })
+            .catch(error => console.error(error));
+    });
+</script>
+@endpush

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -79,5 +79,6 @@
             </div>
         </main>
     </div>
+    @stack('scripts')
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- integrate CKEditor in post create/edit forms
- ensure editor has minimum height of 400px
- allow scripts injection in admin layout

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68604cc9fd80832bb1657ec810fc7aad